### PR TITLE
Constrain Python version to <3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "purr"
 version = "0.1.0"
 description = "CLI wrapper for KittenTTS — model management and speech synthesis"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.14"
 dependencies = [
     "typer>=0.12",
     "sounddevice>=0.4",


### PR DESCRIPTION
## Summary
Updated the Python version requirement to explicitly exclude Python 3.14 and later versions.

## Changes
- Modified `requires-python` constraint in `pyproject.toml` from `>=3.8` to `>=3.8,<3.14`

## Details
This change adds an upper bound to the supported Python versions, ensuring the package is only installed on Python 3.8 through 3.13. This may be necessary due to compatibility concerns with Python 3.14's breaking changes or to allow time for testing before officially supporting the latest Python version.

https://claude.ai/code/session_01H7NqQ6XazJMimsHFrqQyFX